### PR TITLE
Fix for reconnect problems on receive.

### DIFF
--- a/lib/Net/Stomp.pm
+++ b/lib/Net/Stomp.pm
@@ -363,9 +363,9 @@ sub ack {
 sub send_frame {
     my ( $self, $frame ) = @_;
     # see if we're connected before we try to syswrite()
-    if (not defined $self->_connected) {
+    if (not $self->_connected) {
         $self->_reconnect;
-        if (not defined $self->_connected) {
+        if (not $self->_connected) {
             $self->_logdie(q{wasn't connected; couldn't _reconnect()});
         }
     }
@@ -382,7 +382,7 @@ sub send_frame {
     if (not defined $written) {
         $self->logger->warn("error writing frame <<$frame_string>>: $!");
     }
-    unless (defined $written && defined $self->_connected) {
+    unless (defined $written && $self->_connected) {
         $self->_reconnect;
         $self->send_frame($frame);
     }
@@ -494,7 +494,7 @@ sub receive_frame {
 
     my $timeout = exists $conf->{timeout} ? $conf->{timeout} :  $self->timeout;
 
-    unless (defined $self->_connected) {
+    unless ($self->_connected) {
         $self->_reconnect;
     }
 


### PR DESCRIPTION
Currently, Net::Stomp does not reconnect if the activemq server restarts while the connection is open.  
The problem seems to be that the socket->connected returns a different value then expected after the message server restarts.

$self->socket->connected returns 1 when connected.
$self->socket->connected returns a defined but false value (eg. '') if the STOMP server restarts while the connection is open.

Simple change is to drop the check for 'defined' return values for _connected, and instead check for true or false (since undefined is still false).
