### PR TITLE
Add support for 'nack'

### DIFF
--- a/README
+++ b/README
@@ -204,6 +204,14 @@ METHODS
 
       $stomp->ack( { frame => $frame } );
 
+  nack
+    This informs the remote end that you have been unable to process a
+    received frame (if you are using client acknowledgements)
+    (See individual stomp server documentation for information about
+    additional fields that can be passed to alter NACK behavior):
+
+      $stomp->nack( { frame => $frame } );
+
   send_frame
     If this module does not provide enough help for sending frames, you may
     construct your own frame and send it:

--- a/lib/Net/Stomp.pm
+++ b/lib/Net/Stomp.pm
@@ -360,6 +360,17 @@ sub ack {
     return 1;
 }
 
+sub nack {
+    my ( $self, $conf ) = @_;
+    $conf = { %$conf };
+    my $id    = $conf->{frame}->headers->{'message-id'};
+    delete $conf->{frame};
+    my $frame = Net::Stomp::Frame->new(
+        { command => 'NACK', headers => { 'message-id' => $id, %$conf } } );
+    $self->send_frame($frame);
+    return 1;
+}
+
 sub send_frame {
     my ( $self, $frame ) = @_;
     # see if we're connected before we try to syswrite()
@@ -1064,6 +1075,17 @@ This acknowledges that you have received and processed a frame I<and
 all frames before it> (if you are using client acknowledgements):
 
   $stomp->ack( { frame => $frame } );
+
+Always returns a true value.
+
+=head2 C<nack>
+
+This informs the remote end that you have been unable to process a
+received frame (if you are using client acknowledgements)
+(See individual stomp server documentation for information about
+additional fields that can be passed to alter NACK behavior):
+
+  $stomp->nack( { frame => $frame } );
 
 Always returns a true value.
 


### PR DESCRIPTION
Being able to NACK a message is quite important.
We utilize RabbitMQ.  The current version supports a more useful version of NACK.

The old version would immediately requeue the NACK'd message, but give no indication that subsequent redeliveries were in-fact retries, rendering NACK kinda useless unless you want unlimited, instantaneous retries.

Newer versions have added a couple of useful features:
1. Support for "requeue" header, telling the server whether you actually WANT the message to be redelivered or not, and
2. A 'redelivered' header, telling the client that this message has been redelivered as a result of a "NACK w/ requeue=true"

This pull request adds support for nack method.
