### PR TITLE
Avoid referencing $frame if it's undefined

### DIFF
--- a/lib/Net/Stomp.pm
+++ b/lib/Net/Stomp.pm
@@ -193,7 +193,7 @@ sub connect {
         $self->_connect_headers( $conf );
     }
     else {
-        $self->logger->warn('failed to connect',{ %{$frame} });
+        $self->logger->warn('failed to connect',{ %{$frame // {}} });
     }
 
     return $frame;


### PR DESCRIPTION
I get "Can't use an undefined value as a HASH reference" when a connection fails today.  This resolves that issue.