### PR TITLE
Allow "failover" url to work with "ssl" and "ssl_options" parameters

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,10 @@
 Revision history for Perl module Net::Stomp:
 
+0.62 2024-02-08
+ - "failover" URL now works together with "ssl" and "ssl_options"
+   constructor arguments by applying the same SSL settings to all
+   hosts in the failover URL.
+
 0.61 2021-04-13
  - Avoid referencing $frame if it's undefined (thanks Lee Burton
    N6UDP)


### PR DESCRIPTION
The "ssl" and "ssl_options" parameters were ignored when connecting using a "failover" URL. Now the SSL options are set for each host which causes an SSL connection to be used, just like if an explicit "hosts" list with SSL settings was used when creating a Net::Stomp object. This also sort of fixes old CPAN RT #128661 in that it allows failover URL to perform SSL connections.

Also added an extra check that we have a valid socket before calling setsockopt SO_KEEPALIVE on it. This fixes old CPAN RT #118018.